### PR TITLE
query-builder refactoring

### DIFF
--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -35,7 +35,17 @@
         return this.where.apply(this, arguments);
       },
 
+      /**
+       * @method MLQueryBuilder#text
+       * @deprecated
+       */
+      // TODO: replace with what?
+      // * @see MLQueryBuilder#parsedFrom
       text: function text(qtext) {
+        console.log(
+          'Warning, MLQueryBuilder.text is deprecated, and will be removed in the next release!\n' +
+          'Use the qtext property of a structured query in it\'s place'
+        );
         return {
           'qtext': qtext
         };

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -135,45 +135,56 @@
         };
       },
 
+      /**
+       * @method MLQueryBuilder#range
+       * @see MLQueryBuilder.ext.rangeConstraint
+       * @deprecated
+       */
       range: function range(name, values) {
-        values = asArray.apply(null, [values]);
-        return {
-          'range-constraint-query': {
-            'constraint-name': name,
-            'value': values
-          }
-        };
+        console.log(
+          'Warning, MLQueryBuilder.range is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.ext.rangeConstraint in it\'s place'
+        );
+        return this.ext.rangeConstraint.apply(this.ext, arguments);
       },
 
+      /**
+       * @method MLQueryBuilder#collection
+       * @see MLQueryBuilder.ext.collectionConstraint
+       * @deprecated
+       */
       collection: function collection(name, values) {
-        values = asArray.apply(null, [values]);
-        return {
-          'collection-constraint-query': {
-            'constraint-name': name,
-            'uri': values
-          }
-        };
+        console.log(
+          'Warning, MLQueryBuilder.collection is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.ext.collectionConstraint in it\'s place'
+        );
+        return this.ext.collectionConstraint.apply(this.ext, arguments);
       },
 
+      /**
+       * @method MLQueryBuilder#custom
+       * @see MLQueryBuilder.ext.customConstraint
+       * @deprecated
+       */
       custom: function custom(name, values) {
-        values = asArray.apply(null, [values]);
-        return {
-          'custom-constraint-query': {
-            'constraint-name': name,
-            'value': values
-          }
-        };
+        console.log(
+          'Warning, MLQueryBuilder.custom is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.ext.customConstraint in it\'s place'
+        );
+        return this.ext.customConstraint.apply(this.ext, arguments);
       },
 
+      /**
+       * @method MLQueryBuilder#constraint
+       * @see MLQueryBuilder.ext.constraint
+       * @deprecated
+       */
       constraint: function constraint(type) {
-        switch(type) {
-          case 'custom':
-            return this.custom;
-          case 'collection':
-            return this.collection;
-          default:
-            return this.range;
-        }
+        console.log(
+          'Warning, MLQueryBuilder.constraint is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.ext.constraint in it\'s place'
+        );
+        return this.ext.constraint.apply(this.ext, arguments);
       },
 
       operator: function operator(name, stateName) {
@@ -183,6 +194,93 @@
             'state-name': stateName
           }
         };
+      },
+
+      /**
+       * query builder extensions
+       * @memberof MLQueryBuilder
+       * @type {Object}
+       */
+      ext: {
+
+        /**
+         * Builds a [`range-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_38268)
+         * @memberof! MLQueryBuilder
+         * @method ext.rangeConstraint
+         *
+         * @param {String} name - constraint name
+         * @param {Array} values - the values the constraint should equal (logical OR)
+         * @return {Object} [range-constraint-query](http://docs.marklogic.com/guide/search-dev/structured-query#id_38268)
+         */
+        rangeConstraint: function rangeConstraint(name, values) {
+          values = asArray.apply(null, [values]);
+          return {
+            'range-constraint-query': {
+              'constraint-name': name,
+              'value': values
+            }
+          };
+        },
+
+        /**
+         * Builds a [`collection-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_30776)
+         * @memberof! MLQueryBuilder
+         * @method ext.collectionConstraint
+         *
+         * @param {String} name - constraint name
+         * @param {Array} values - the values the constraint should equal (logical OR)
+         * @return {Object} [collection-constraint-query](http://docs.marklogic.com/guide/search-dev/structured-query#id_30776)
+         */
+        collectionConstraint: function collectionConstraint(name, values) {
+          values = asArray.apply(null, [values]);
+          return {
+            'collection-constraint-query': {
+              'constraint-name': name,
+              'uri': values
+            }
+          };
+        },
+
+        /**
+         * Builds a [`custom-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_28778)
+         * @memberof! MLQueryBuilder
+         * @method ext.customConstraint
+         *
+         * @param {String} name - constraint name
+         * @param {Array} values - the values the constraint should equal (logical OR)
+         * @return {Object} [custom-constraint-query](http://docs.marklogic.com/guide/search-dev/structured-query#id_28778)
+         */
+        customConstraint: function customConstraint(name, values) {
+          values = asArray.apply(null, [values]);
+          return {
+            'custom-constraint-query': {
+              'constraint-name': name,
+              'value': values
+            }
+          };
+        },
+
+        /**
+         * constraint query function factory
+         * @memberof! MLQueryBuilder
+         * @method ext.constraint
+         *
+         * @param {String} type - constraint type (`'collection' | 'custom' | '*'`)
+         * @return {Function} a constraint query builder function, one of:
+         *   - {@link MLQueryBuilder.ext.rangeConstraint}
+         *   - {@link MLQueryBuilder.ext.collectionConstraint}
+         *   - {@link MLQueryBuilder.ext.customConstraint}
+         */
+        constraint: function constraint(type) {
+          switch(type) {
+            case 'custom':
+              return this.customConstraint;
+            case 'collection':
+              return this.collectionConstraint;
+            default:
+              return this.rangeConstraint;
+          }
+        }
       }
 
     };

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -37,14 +37,13 @@
 
       /**
        * @method MLQueryBuilder#text
+       * @see MLQueryBuilder.ext.combined
        * @deprecated
        */
-      // TODO: replace with what?
-      // * @see MLQueryBuilder#parsedFrom
       text: function text(qtext) {
         console.log(
           'Warning, MLQueryBuilder.text is deprecated, and will be removed in the next release!\n' +
-          'Use the qtext property of a structured query in it\'s place'
+          'Use the qtext argument of MLQueryBuilder.ext.combined in it\'s place'
         );
         return {
           'qtext': qtext
@@ -208,6 +207,31 @@
       ext: {
 
         /**
+         * Builds a [combined query](http://docs.marklogic.com/guide/rest-dev/search#id_69918)
+         * @memberof! MLQueryBuilder
+         * @method ext.combined
+         *
+         * @param {Object} query - a structured query (from {@link MLQueryBuilder#where})
+         * @param {String} [qtext] - a query text string, to be parsed server-side
+         * @param {Object} [options] - search options
+         * @return {Object} combined query
+         */
+        combined: function combined(query, qtext, options) {
+          if ( isObject(qtext) && !options ) {
+            options = qtext;
+            qtext = null;
+          }
+
+          return {
+            search: {
+              query: query.query || query,
+              qtext: qtext,
+              options: options.options || options
+            }
+          };
+        },
+
+        /**
          * Builds a [`range-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_38268)
          * @memberof! MLQueryBuilder
          * @method ext.rangeConstraint
@@ -325,6 +349,12 @@
     }
 
     return args;
+  }
+
+  // from lodash
+  function isObject(value) {
+    var type = typeof value;
+    return !!value && (type == 'object' || type == 'function');
   }
 
 

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -52,6 +52,26 @@
       },
 
       /**
+       * @method MLQueryBuilder#properties
+       * @deprecated
+       */
+      properties: function properties(query) {
+        console.log(
+          'Warning, MLQueryBuilder.properties is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.propertiesFragment in it\'s place'
+        );
+        return this.propertiesFragment.apply(this, arguments);
+      },
+
+      /**
+       * @method MLQueryBuilder#propertiesFragment
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#propertiesFragment
+       */
+      propertiesFragment: function propertiesFragment(query) {
+        return { 'properties-fragment-query': query };
+      },
+
+      /**
        * @method MLQueryBuilder#where
        * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#where
        */
@@ -154,10 +174,6 @@
           default:
             return this.range;
         }
-      },
-
-      properties: function properties(query) {
-        return { 'properties-query': query };
       },
 
       operator: function operator(name, stateName) {

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -4,6 +4,11 @@
   angular.module('ml.common')
     .factory('MLQueryBuilder', MLQueryBuilder);
 
+  /**
+   * @class MLQueryBuilder
+   * @classdesc angular service for building structured queries; a subset of
+   * [node-client queryBuilder](http://docs.marklogic.com/jsdoc/queryBuilder.html), plus extensions.
+   */
   function MLQueryBuilder() {
     return {
 
@@ -31,6 +36,10 @@
         };
       },
 
+      /**
+       * @method MLQueryBuilder#or
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#or
+       */
       or: function or() {
         var args = asArray.apply(null, arguments);
         return {
@@ -40,17 +49,38 @@
         };
       },
 
+      /**
+       * @method MLQueryBuilder#not
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#not
+       */
       not: function properties(query) {
         return {
           'not-query': query
         };
       },
 
+      /**
+       * @method MLQueryBuilder#document
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#document
+       */
       document: function document() {
         var args = asArray.apply(null, arguments);
         return {
           'document-query': {
             'uri': args
+          }
+        };
+      },
+
+      /**
+       * @method MLQueryBuilder#boost
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#boost
+       */
+      boost: function boost(matching, boosting) {
+        return {
+          'boost-query': {
+            'matching-query': matching,
+            'boosting-query': boosting
           }
         };
       },
@@ -94,15 +124,6 @@
           default:
             return this.range;
         }
-      },
-
-      boost: function boost(matching, boosting) {
-        return {
-          'boost-query': {
-            'matching-query': matching,
-            'boosting-query': boosting
-          }
-        };
       },
 
       properties: function properties(query) {

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -187,13 +187,17 @@
         return this.ext.constraint.apply(this.ext, arguments);
       },
 
+      /**
+       * @method MLQueryBuilder#operator
+       * @see MLQueryBuilder.ext.operator
+       * @deprecated
+       */
       operator: function operator(name, stateName) {
-        return {
-          'operator-state': {
-            'operator-name': name,
-            'state-name': stateName
-          }
-        };
+        console.log(
+          'Warning, MLQueryBuilder.operator is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.ext.operator in it\'s place'
+        );
+        return this.ext.operatorState.apply(this.ext, arguments);
       },
 
       /**
@@ -280,6 +284,24 @@
             default:
               return this.rangeConstraint;
           }
+        },
+
+        /**
+         * Builds an [`operator-state` query component](http://docs.marklogic.com/guide/search-dev/structured-query#id_45570)
+         * @memberof! MLQueryBuilder
+         * @method ext.operatorState
+         *
+         * @param {String} name - operator name
+         * @param {String} stateName - operator-state name
+         * @return {Object} [operator-state component](http://docs.marklogic.com/guide/search-dev/structured-query#id_45570)
+         */
+        operatorState: function operatorState(name, stateName) {
+          return {
+            'operator-state': {
+              'operator-name': name,
+              'state-name': stateName
+            }
+          };
         }
       }
 

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -10,15 +10,29 @@
    * [node-client queryBuilder](http://docs.marklogic.com/jsdoc/queryBuilder.html), plus extensions.
    */
   function MLQueryBuilder() {
+
+    function where() {
+      var args = asArray.apply(null, arguments);
+      return {
+        'query': {
+          'queries': args
+        }
+      };
+    }
+
     return {
 
-      query: function query() {
-        var args = asArray.apply(null, arguments);
-        return {
-          'query': {
-            'queries': args
-          }
-        };
+      /**
+       * @method MLQueryBuilder#query
+       * @see MLQueryBuilder#where
+       * @deprecated
+       */
+      query: function() {
+        console.log(
+          'Warning, MLQueryBuilder.query is deprecated, and will be removed in the next release!\n' +
+          'Use MLQueryBuilder.where in it\'s place'
+        );
+        return this.where.apply(this, arguments);
       },
 
       text: function text(qtext) {
@@ -26,6 +40,12 @@
           'qtext': qtext
         };
       },
+
+      /**
+       * @method MLQueryBuilder#where
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#where
+       */
+      where: where,
 
       and: function and() {
         var args = asArray.apply(null, arguments);

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -87,7 +87,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a range-query with one value', function() {
-    var query = qb.range('test', 'value');
+    var query = qb.ext.rangeConstraint('test', 'value');
+
+    var oldQuery = qb.range('test', 'value');
+    expect(query).toEqual(oldQuery);
 
     expect(query['range-constraint-query']).toBeDefined();
     expect(query['range-constraint-query']['constraint-name']).toEqual('test');
@@ -96,7 +99,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a range-query with multiple values', function() {
-    var query = qb.range('test', ['value1', 'value2']);
+    var query = qb.ext.rangeConstraint('test', ['value1', 'value2']);
+
+    var oldQuery = qb.range('test', ['value1', 'value2']);
+    expect(query).toEqual(oldQuery);
 
     expect(query['range-constraint-query']).toBeDefined();
     expect(query['range-constraint-query']['constraint-name']).toEqual('test');
@@ -106,7 +112,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a collection-query with one collection', function() {
-    var query = qb.collection('name', 'uri');
+    var query = qb.ext.collectionConstraint('name', 'uri');
+
+    var oldQuery = qb.collection('name', 'uri');
+    expect(query).toEqual(oldQuery);
 
     expect(query['collection-constraint-query']).toBeDefined();
     expect(query['collection-constraint-query']['constraint-name']).toEqual('name');
@@ -115,7 +124,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a collection-query with multiple collections', function() {
-    var query = qb.collection('name', ['uri1', 'uri2']);
+    var query = qb.ext.collectionConstraint('name', ['uri1', 'uri2']);
+
+    var oldQuery = qb.collection('name', ['uri1', 'uri2']);
+    expect(query).toEqual(oldQuery);
 
     expect(query['collection-constraint-query']).toBeDefined();
     expect(query['collection-constraint-query']['constraint-name']).toEqual('name');
@@ -125,7 +137,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a custom-query with one value', function() {
-    var query = qb.custom('test', 'value');
+    var query = qb.ext.customConstraint('test', 'value');
+
+    var oldQuery = qb.custom('test', 'value');
+    expect(query).toEqual(oldQuery);
 
     expect(query['custom-constraint-query']).toBeDefined();
     expect(query['custom-constraint-query']['constraint-name']).toEqual('test');
@@ -134,7 +149,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a custom-query with multiple values', function() {
-    var query = qb.custom('test', ['value1', 'value2']);
+    var query = qb.ext.customConstraint('test', ['value1', 'value2']);
+
+    var oldQuery = qb.custom('test', ['value1', 'value2']);
+    expect(query).toEqual(oldQuery);
 
     expect(query['custom-constraint-query']).toBeDefined();
     expect(query['custom-constraint-query']['constraint-name']).toEqual('test');
@@ -146,14 +164,21 @@ describe('MLQueryBuilder', function () {
   it('chooses a constraint query by type', function() {
     var constraint;
 
-    constraint = qb.constraint(null)
-    expect(constraint('name', 'value')).toEqual(qb.range('name', 'value'))
+    constraint = qb.ext.constraint(null);
+    expect(constraint('name', 'value')).toEqual(qb.ext.rangeConstraint('name', 'value'));
 
-    constraint = qb.constraint('collection')
-    expect(constraint('name', 'value')).toEqual(qb.collection('name', 'value'))
+    var oldConstraint = qb.constraint(null);
 
-    constraint = qb.constraint('custom')
-    expect(constraint('name', 'value')).toEqual(qb.custom('name', 'value'))
+    expect(constraint('name', 'value')).toEqual(oldConstraint('name', 'value'));
+
+    constraint = qb.ext.constraint('range')
+    expect(constraint('name', 'value')).toEqual(qb.ext.rangeConstraint('name', 'value'))
+
+    constraint = qb.ext.constraint('collection');
+    expect(constraint('name', 'value')).toEqual(qb.ext.collectionConstraint('name', 'value'));
+
+    constraint = qb.ext.constraint('custom');
+    expect(constraint('name', 'value')).toEqual(qb.ext.customConstraint('name', 'value'));
   });
 
   it('builds a boost query', function() {

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -167,10 +167,13 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds a properties query', function() {
-    var query = qb.properties( qb.and() );
+    var query = qb.propertiesFragment( qb.and() );
 
-    expect(query['properties-query']).toBeDefined();
-    expect(query['properties-query']).toEqual( qb.and() );
+    var oldQuery = qb.properties( qb.and() );
+    expect(query).toEqual(oldQuery);
+
+    expect(query['properties-fragment-query']).toBeDefined();
+    expect(query['properties-fragment-query']).toEqual( qb.and() );
   });
 
   it('builds an operator query', function() {

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -12,10 +12,17 @@ describe('MLQueryBuilder', function () {
   }));
 
   it('builds a query', function() {
-    var query = qb.query();
+    var query = qb.where();
+
+    var oldQuery = qb.query();
+    expect(query).toEqual(oldQuery);
+
     expect(query.query).toBeDefined;
     expect(query.query.queries.length).toEqual(0);
-    query = qb.query(qb.and())
+
+    query = qb.where(qb.and())
+    oldQuery = qb.query(qb.and())
+
     expect(query.query.queries.length).toEqual(1);
   });
 

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -212,4 +212,26 @@ describe('MLQueryBuilder', function () {
     expect(query['operator-state']['state-name']).toEqual('date');
   });
 
+  it('builds a combined query', function() {
+    var query = qb.and();
+
+    var combined = qb.ext.combined(query, 'blah', {})
+
+    expect(combined.search).toBeDefined();
+    expect(combined.search.query).toEqual(query);
+    expect(combined.search.qtext).toEqual('blah');
+    expect(combined.search.options).toEqual({});
+
+    query = qb.or();
+    combined = qb.ext.combined(query, {
+      options: { 'return-query': 0 }
+    });
+
+    expect(combined.search).toBeDefined();
+    expect(combined.search.query).toEqual(query);
+    expect(combined.search.qtext).toBeNull();
+    expect(combined.search.options).toBeDefined();
+    expect(combined.search.options['return-query']).toEqual(0);
+  });
+
 });

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -202,7 +202,10 @@ describe('MLQueryBuilder', function () {
   });
 
   it('builds an operator query', function() {
-    var query = qb.operator('sort', 'date');
+    var query = qb.ext.operatorState('sort', 'date');
+
+    var oldQuery = qb.operator('sort', 'date');
+    expect(query).toEqual(oldQuery);
 
     expect(query['operator-state']).toBeDefined();
     expect(query['operator-state']['operator-name']).toEqual('sort');


### PR DESCRIPTION
This PR is the first step in a longer process of query-builder refactoring and improvement. As a first step, it deprecates custom functionality, replacing it with methods that match the official `node-client-api` query-builder. It moves additional functionality, specifically constraint-queries, to an `ext` property on the query-builder, to allow for compatibility as well as extension.

Additionally, it deprecates `text()` (which is only partially supported, and should simply be a property of a combined query) and updates `propertiesFragment()` to use the ML 8 syntax.

re #1 #11

/cc @grtjn