### PR TITLE
adds backwards-compat qb methods

### DIFF
--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -250,6 +250,38 @@
         },
 
         /**
+         * Builds a [`value-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_63420)
+         * @memberof! MLQueryBuilder
+         * @method ext.valueConstraint
+         *
+         * @param {String} name - constraint name
+         * @param {String|Number|Array<String>|Array<Number>|null} values - the values the constraint should equal (logical OR)
+         * @return {Object} [`value-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_63420)
+         */
+        valueConstraint: function valueConstraint(name, values) {
+          var query = {
+            'value-constraint-query': {
+              'constraint-name': name
+            }
+          };
+
+          var type;
+
+          if (values === null) {
+            type = 'null';
+            values = [];
+          } else {
+            values = asArray(values);
+            type = typeof values[0];
+            type = ((type === 'string') && 'text') || type;
+          }
+
+          query['value-constraint-query'][type] = values;
+
+          return query;
+        },
+
+        /**
          * Builds a [`collection-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_30776)
          * @memberof! MLQueryBuilder
          * @method ext.collectionConstraint
@@ -293,11 +325,14 @@
          * @param {String} type - constraint type (`'collection' | 'custom' | '*'`)
          * @return {Function} a constraint query builder function, one of:
          *   - {@link MLQueryBuilder.ext.rangeConstraint}
+         *   - {@link MLQueryBuilder.ext.valueConstraint}
          *   - {@link MLQueryBuilder.ext.collectionConstraint}
          *   - {@link MLQueryBuilder.ext.customConstraint}
          */
         constraint: function constraint(type) {
           switch(type) {
+            case 'value':
+              return this.valueConstraint;
             case 'custom':
               return this.customConstraint;
             case 'collection':

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -151,6 +151,19 @@
       },
 
       /**
+       * @method MLQueryBuilder#term
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#term
+       */
+      term: function term() {
+        var args = asArray.apply(null, arguments);
+        return {
+          'term-query': {
+            'text': args
+          }
+        };
+      },
+
+      /**
        * @method MLQueryBuilder#range
        * @see MLQueryBuilder.ext.rangeConstraint
        * @deprecated

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -282,6 +282,24 @@
         },
 
         /**
+         * Builds a [`word-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_66833)
+         * @memberof! MLQueryBuilder
+         * @method ext.wordConstraint
+         *
+         * @param {String} name - constraint name
+         * @param {String|Array<String>} values - the values the constraint should equal (logical OR)
+         * @return {Object} [`word-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_66833)
+         */
+        wordConstraint: function wordConstraint(name, values) {
+          return {
+            'word-constraint-query': {
+              'constraint-name': name,
+              'text': asArray(values)
+            }
+          };
+        },
+
+        /**
          * Builds a [`collection-constraint-query`](http://docs.marklogic.com/guide/search-dev/structured-query#id_30776)
          * @memberof! MLQueryBuilder
          * @method ext.collectionConstraint
@@ -326,6 +344,7 @@
          * @return {Function} a constraint query builder function, one of:
          *   - {@link MLQueryBuilder.ext.rangeConstraint}
          *   - {@link MLQueryBuilder.ext.valueConstraint}
+         *   - {@link MLQueryBuilder.ext.wordConstraint}
          *   - {@link MLQueryBuilder.ext.collectionConstraint}
          *   - {@link MLQueryBuilder.ext.customConstraint}
          */
@@ -333,6 +352,8 @@
           switch(type) {
             case 'value':
               return this.valueConstraint;
+            case 'word':
+              return this.wordConstraint;
             case 'custom':
               return this.customConstraint;
             case 'collection':

--- a/src/ml-query-builder.service.js
+++ b/src/ml-query-builder.service.js
@@ -63,14 +63,6 @@
       },
 
       /**
-       * @method MLQueryBuilder#propertiesFragment
-       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#propertiesFragment
-       */
-      propertiesFragment: function propertiesFragment(query) {
-        return { 'properties-fragment-query': query };
-      },
-
-      /**
        * @method MLQueryBuilder#where
        * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#where
        */
@@ -106,6 +98,30 @@
         return {
           'not-query': query
         };
+      },
+
+      /**
+       * @method MLQueryBuilder#documentFragment
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#documentFragment
+       */
+      documentFragment: function documentFragment(query) {
+        return { 'document-fragment-query': query };
+      },
+
+      /**
+       * @method MLQueryBuilder#propertiesFragment
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#propertiesFragment
+       */
+      propertiesFragment: function propertiesFragment(query) {
+        return { 'properties-fragment-query': query };
+      },
+
+      /**
+       * @method MLQueryBuilder#locksFragment
+       * @see http://docs.marklogic.com/jsdoc/queryBuilder.html#locksFragment
+       */
+      locksFragment: function locksFragment(query) {
+        return { 'locks-fragment-query': query };
       },
 
       /**

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -259,7 +259,14 @@ describe('MLQueryBuilder', function () {
     expect(query['boost-query']['boosting-query'].qtext).toEqual('blah');
   });
 
-  it('builds a properties query', function() {
+  it('builds a document-fragment query', function() {
+    var query = qb.documentFragment( qb.and() );
+
+    expect(query['document-fragment-query']).toBeDefined();
+    expect(query['document-fragment-query']).toEqual( qb.and() );
+  });
+
+  it('builds a properties-fragment query', function() {
     var query = qb.propertiesFragment( qb.and() );
 
     var oldQuery = qb.properties( qb.and() );
@@ -267,6 +274,13 @@ describe('MLQueryBuilder', function () {
 
     expect(query['properties-fragment-query']).toBeDefined();
     expect(query['properties-fragment-query']).toEqual( qb.and() );
+  });
+
+  it('builds a locks-fragment query', function() {
+    var query = qb.locksFragment( qb.and() );
+
+    expect(query['locks-fragment-query']).toBeDefined();
+    expect(query['locks-fragment-query']).toEqual( qb.and() );
   });
 
   it('builds an operator query', function() {

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -161,6 +161,49 @@ describe('MLQueryBuilder', function () {
     expect(query['custom-constraint-query']['value'][1]).toEqual('value2');
   });
 
+  it('builds a value-constraint-query with one value', function() {
+    var query = qb.ext.valueConstraint('test', 'value');
+
+    expect(query['value-constraint-query']).toBeDefined();
+    expect(query['value-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['value-constraint-query']['text'].length).toEqual(1);
+    expect(query['value-constraint-query']['text'][0]).toEqual('value');
+
+    query = null;
+    query = qb.ext.valueConstraint('test', 1);
+
+    expect(query['value-constraint-query']).toBeDefined();
+    expect(query['value-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['value-constraint-query']['number'].length).toEqual(1);
+    expect(query['value-constraint-query']['number'][0]).toEqual(1);
+
+    query = null;
+    query = qb.ext.valueConstraint('test', null);
+
+    expect(query['value-constraint-query']).toBeDefined();
+    expect(query['value-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['value-constraint-query']['null'].length).toEqual(0);
+  });
+
+  it('builds a value-constraint-query with multiple values', function() {
+    var query = qb.ext.valueConstraint('test', ['value1', 'value2']);
+
+    expect(query['value-constraint-query']).toBeDefined();
+    expect(query['value-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['value-constraint-query']['text'].length).toEqual(2);
+    expect(query['value-constraint-query']['text'][0]).toEqual('value1');
+    expect(query['value-constraint-query']['text'][1]).toEqual('value2');
+
+    query = null;
+    query = qb.ext.valueConstraint('test', [1, 2]);
+
+    expect(query['value-constraint-query']).toBeDefined();
+    expect(query['value-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['value-constraint-query']['number'].length).toEqual(2);
+    expect(query['value-constraint-query']['number'][0]).toEqual(1);
+    expect(query['value-constraint-query']['number'][1]).toEqual(2);
+  });
+
   it('chooses a constraint query by type', function() {
     var constraint;
 
@@ -179,6 +222,12 @@ describe('MLQueryBuilder', function () {
 
     constraint = qb.ext.constraint('custom');
     expect(constraint('name', 'value')).toEqual(qb.ext.customConstraint('name', 'value'));
+
+    constraint = qb.ext.constraint('value');
+    expect(constraint('name', 'value')).toEqual(qb.ext.valueConstraint('name', 'value'));
+
+    constraint = qb.ext.constraint('word');
+    expect(constraint('name', 'value')).toEqual(qb.ext.wordConstraint('name', 'value'));
   });
 
   it('builds a boost query', function() {

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -204,6 +204,25 @@ describe('MLQueryBuilder', function () {
     expect(query['value-constraint-query']['number'][1]).toEqual(2);
   });
 
+  it('builds a word-constraint-query with one value', function() {
+    var query = qb.ext.wordConstraint('test', 'value');
+
+    expect(query['word-constraint-query']).toBeDefined();
+    expect(query['word-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['word-constraint-query']['text'].length).toEqual(1);
+    expect(query['word-constraint-query']['text'][0]).toEqual('value');
+  });
+
+  it('builds a word-constraint-query with multiple values', function() {
+    var query = qb.ext.wordConstraint('test', ['value1', 'value2']);
+
+    expect(query['word-constraint-query']).toBeDefined();
+    expect(query['word-constraint-query']['constraint-name']).toEqual('test');
+    expect(query['word-constraint-query']['text'].length).toEqual(2);
+    expect(query['word-constraint-query']['text'][0]).toEqual('value1');
+    expect(query['word-constraint-query']['text'][1]).toEqual('value2');
+  });
+
   it('chooses a constraint query by type', function() {
     var constraint;
 

--- a/test/spec/ml-query-builder.service.js
+++ b/test/spec/ml-query-builder.service.js
@@ -86,6 +86,23 @@ describe('MLQueryBuilder', function () {
     expect(query['document-query'].uri[1]).toEqual('uri2');
   });
 
+  it('builds a term query with one value', function() {
+    var query = qb.term('foo');
+
+    expect(query['term-query']).toBeDefined();
+    expect(query['term-query'].text.length).toEqual(1);
+    expect(query['term-query'].text[0]).toEqual('foo');
+  });
+
+  it('builds a term query with multiple values', function() {
+    var query = qb.term(['foo', 'bar']);
+
+    expect(query['term-query']).toBeDefined();
+    expect(query['term-query'].text.length).toEqual(2);
+    expect(query['term-query'].text[0]).toEqual('foo');
+    expect(query['term-query'].text[1]).toEqual('bar');
+  });
+
   it('builds a range-query with one value', function() {
     var query = qb.ext.rangeConstraint('test', 'value');
 


### PR DESCRIPTION
re #14

Notes:

- looking forward towards compatibility with the node-client-api, the weight parameters have been removed. We'll need to add/use `qb.weight()` to support custom query weights.
- docs need to be fleshed out more, to explain the kind of one-way compatibility being supported

/cc @grtjn